### PR TITLE
Fixed hiding of `ro` stick when resizable=false

### DIFF
--- a/src/drr.vue
+++ b/src/drr.vue
@@ -8,7 +8,7 @@
     <div
       v-for="stick in sticks"
       class="drr-stick"
-      :class="['drr-stick-' + stick, resizable ? '' : 'not-resizable']"
+      :class="['drr-stick-' + stick]"
       @mousedown.stop.prevent="stickDown(stick, $event)"
       @touchstart.stop.prevent="stickDown(stick, $event)"
       :style="drrStick(stick)">
@@ -499,7 +499,7 @@
       },
 
       stickDown: function (stick, ev) {
-        if (!this.resizable || !this.active)
+        if (!this.active)
           return
 
         this.resizeStartEmitted = false


### PR DESCRIPTION
When `resizable` props is set to `false` the `ro` stick also gets hidden.

Before fix:
This code -> ttp://prntscr.com/oqhzf0
Results to this -> http://prntscr.com/oqhzf0

After fix result:
http://prntscr.com/oqi0x8